### PR TITLE
Refactor commodity-balance equality and add units tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ tests/testdb/test.properties
 tests/testdb/ixmptest.properties
 tests/testdb/ixmptest.lck
 .Rproj.user
+
+# pytest cache
+.pytest_cache/**

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -590,15 +590,13 @@ COMMODITY_EQUIVALENCE(node,commodity,level,year,time)$( map_commodity(node,commo
 
 * Equation COMMODITY_BALANCE_GT
 * """""""""""""""""""""""""""""
-* This constraint ensures the supply to be lower than or equal to the demand for every commodity and level
-* considered in Equation COMMODITY_EQUIVALENCE
-
+* This constraint ensures that supply is greater than demand for every commodity-level combination.
 *
 *
 ***
-
-COMMODITY_BALANCE_GT(node,commodity,level,year,time)..
-        COMM(node,commodity,level,year,time) =G= 0;
+COMMODITY_BALANCE_GT(node,commodity,level,year,time)$( map_commodity(node,commodity,level,year,time)
+        AND NOT level_resource(level) AND NOT level_renewable(level) )..
+    COMM(node,commodity,level,year,time) =G= 0 ;
 
 * Equation COMMODITY_BALANCE_LT
 * """""""""""""""""""""""""""""
@@ -607,9 +605,10 @@ COMMODITY_BALANCE_GT(node,commodity,level,year,time)..
 *
 *
 ***
-
-COMMODITY_BALANCE_LT(node,commodity,level,year,time)$( balance_equality(commodity,level) )..
-        COMM(node,commodity,level,year,time) =L= 0;
+COMMODITY_BALANCE_LT(node,commodity,level,year,time)$( map_commodity(node,commodity,level,year,time)
+        AND NOT level_resource(level) AND NOT level_renewable(level)
+        AND balance_equality(commodity,level) )..
+    COMM(node,commodity,level,year,time) =L= 0 ;
 
 ***
 * Equation STOCKS_BALANCE

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -152,7 +152,7 @@ Variables
 * Variable                                      Explanatory text
 * ============================================= ========================================================================
 * :math:`DEMAND_{n,c,l,y,h} \in \mathbb{R}`     Demand level (in equilibrium with MACRO integration)
-* :math:`PRICE\_COMMODITY_{n,c,l,y,h}`          Commodity price (undiscounted marginals of COMMODITY_BALANCE constraint)
+* :math:`PRICE\_COMMODITY_{n,c,l,y,h}`          Commodity price (undiscounted marginals of the commodity balances)
 * :math:`PRICE\_EMISSION_{n,e,\widehat{t},y}`   Emission price (undiscounted marginals of EMISSION_BOUND constraint)
 * :math:`COST\_NODAL\_NET_{n,y} \in \mathbb{R}` System costs at the node level net of energy trade revenues/cost
 * :math:`GDP_{n,y} \in \mathbb{R}`              gross domestic product (GDP) in market exchange rates for MACRO reporting
@@ -253,7 +253,6 @@ Equations
     EXTRACTION_BOUND_UP             upper bound on extraction (by grade)
     RESOURCE_CONSTRAINT             constraint on resources remaining in each period (maximum extraction per period)
     RESOURCE_HORIZON                constraint on extraction over entire model horizon (resource volume in place)
-    COMMODITY_EQUIVALENCE           commodity supply-demand lower balance constraint
     COMMODITY_BALANCE_GT            commodity supply greater than or equal demand
     COMMODITY_BALANCE_LT            commodity supply lower than or equal demand
     STOCKS_BALANCE                  commodity inter-temporal balance of stocks
@@ -547,9 +546,10 @@ RESOURCE_HORIZON(node,commodity,grade)$( SUM(year$map_resource(node,commodity,gr
 * Constraints on commodities and stocks
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
-* Equation COMMODITY_EQUIVALENCE
-* """"""""""""""""""""""""""""""
-* This constraint accounts for the nodal and temporal balance of outputs/imports and inputs/exports for all commodities.
+* Auxiliary COMMODITY_BALANCE
+* """""""""""""""""""""""""""
+* For the commodity balance constraints below, we introduce an auxiliary `COMMODITY_BALANCE`. This is implemented
+* as a GAMS `$macro` function. 
 *
 *  .. math::
 *     \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y}} output_{n^L,t,y^V,y,m,n,c,l,h^A,h}
@@ -559,56 +559,63 @@ RESOURCE_HORIZON(node,commodity,grade)$( SUM(year$map_resource(node,commodity,gr
 *     + \ STOCK\_CHG_{n,c,l,y,h} & \\[4pt]
 *     + \ \sum_s \Big( land\_output_{n,s,y,c,l,h} - land\_input_{n,s,y,c,l,h} \Big) \cdot & LAND_{n,s,y} \\[4pt]
 *     - \ demand\_fixed_{n,c,l,y,h}
-*     & \eq COMM_{n,c,l,y,h} \quad \forall \ l \notin L^{RES} \subseteq L
+*     & = COMMODITY\_BALANCE{n,c,l,y,h} \quad \forall \ l \notin (L^{RES}, l^{REN} \subseteq L
 *
 * The commodity balance constraint at the resource level is included in the `Equation RESOURCE_CONSTRAINT`_,
 * while at the renewable level, it is included in the `Equation RENEWABLES_EQUIVALENCE`_.
 ***
-COMMODITY_EQUIVALENCE(node,commodity,level,year,time)$( map_commodity(node,commodity,level,year,time)
-                  AND NOT level_resource(level) AND NOT level_renewable(level) )..
-    SUM( (location,tec,vintage,mode,time2)$( map_tec_act(location,tec,year,mode,time2)
-            AND map_tec_lifetime(location,tec,vintage,year) ),
+$macro COMMODITY_BALANCE(node,commodity,level,year,time) (                                                             \
+    SUM( (location,tec,vintage,mode,time2)$( map_tec_act(location,tec,year,mode,time2)                                 \
+            AND map_tec_lifetime(location,tec,vintage,year) ),                                                         \
 * import into node and output by all technologies located at 'location' sending to 'node' and 'time2' sending to 'time'
-        output(location,tec,vintage,year,mode,node,commodity,level,time2,time)
-        * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time2)
+        output(location,tec,vintage,year,mode,node,commodity,level,time2,time)                                         \                    
+        * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time2)                                    \
 * export from node and input into technologies located at 'location' taking from 'node' and 'time2' taking from 'time'
-        - input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
-        * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time2) )
+        - input(location,tec,vintage,year,mode,node,commodity,level,time2,time)                                        \
+        * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time2) )                                  \
 * quantity taken out from ( >0 ) or put into ( <0 ) inter-period stock (storage)
-    + STOCK_CHG(node,commodity,level,year,time)$( map_stocks(node,commodity,level,year) )
+    + STOCK_CHG(node,commodity,level,year,time)$( map_stocks(node,commodity,level,year) )                              \
 * yield from land-use model emulator
-    + SUM(land_scenario,
-        ( land_output(node,land_scenario,year,commodity,level,time)
-          - land_input(node,land_scenario,year,commodity,level,time) ) * LAND(node,land_scenario,year) )
-* final consumption (exogenous parameter to be satisfied by the energy+water+xxx system)
-    - demand_fixed(node,commodity,level,year,time)
-* relaxation of constraints for debugging
-%SLACK_COMMODITY_EQUIVALENCE%   + SLACK_COMMODITY_EQUIVALENCE_UP(node,commodity,level,year,time)
-%SLACK_COMMODITY_EQUIVALENCE%   - SLACK_COMMODITY_EQUIVALENCE_LO(node,commodity,level,year,time)
-* equality to auxiliary variable COMM
-    =E= COMM(node,commodity,level,year,time) ;
+    + SUM(land_scenario,                                                                                               \
+        ( land_output(node,land_scenario,year,commodity,level,time)                                                    \
+          - land_input(node,land_scenario,year,commodity,level,time) ) * LAND(node,land_scenario,year) )               \
+* final demand (exogenous parameter to be satisfied by the commodity system)                              
+    - demand_fixed(node,commodity,level,year,time)                                                                     \
+    )$( map_commodity(node,commodity,level,year,time) AND NOT level_resource(level) AND NOT level_renewable(level) )
+
 
 * Equation COMMODITY_BALANCE_GT
 * """""""""""""""""""""""""""""
-* This constraint ensures that supply is greater than demand for every commodity-level combination.
+* This constraint ensures that supply is greater or equal than demand for every commodity-level combination.
 *
+*  .. math::
+*     COMMODITY\_BALANCE{n,c,l,y,h} \geq 0
 *
 ***
 COMMODITY_BALANCE_GT(node,commodity,level,year,time)$( map_commodity(node,commodity,level,year,time)
         AND NOT level_resource(level) AND NOT level_renewable(level) )..
-    COMM(node,commodity,level,year,time) =G= 0 ;
+    COMMODITY_BALANCE(node,commodity,level,year,time)
+* relaxation of constraints for debugging
+%SLACK_COMMODITY_EQUIVALENCE% + SLACK_COMMODITY_EQUIVALENCE_UP(node,commodity,level,year,time)
+     =G= 0 ;
 
 * Equation COMMODITY_BALANCE_LT
 * """""""""""""""""""""""""""""
-* This constraint ensures the supply to be greater than or equal to the demand for specific commodities and levels
-* defined with `balance_equality` at the nodal and temporal level
+* This constraint ensures the supply is smaller than or equal to the demand for all commodity-level combinatio
+* given in the :math:`balance\_equality_{c,l}`. In combination withe constraint above, it ensures that supply
+* is (exactly) equal to demand.
 *
+*  .. math::
+*     COMMODITY\_BALANCE{n,c,l,y,h} \leq 0
 *
 ***
 COMMODITY_BALANCE_LT(node,commodity,level,year,time)$( map_commodity(node,commodity,level,year,time)
         AND NOT level_resource(level) AND NOT level_renewable(level)
         AND balance_equality(commodity,level) )..
-    COMM(node,commodity,level,year,time) =L= 0 ;
+    COMMODITY_BALANCE(node,commodity,level,year,time)
+* relaxation of constraints for debugging
+%SLACK_COMMODITY_EQUIVALENCE% - SLACK_COMMODITY_EQUIVALENCE_LO(node,commodity,level,year,time)
+    =L= 0 ;
 
 ***
 * Equation STOCKS_BALANCE

--- a/message_ix/model/MESSAGE/model_solve.gms
+++ b/message_ix/model/MESSAGE/model_solve.gms
@@ -47,8 +47,8 @@ EMISSION_CONSTRAINT.m(node,type_emission,type_tec,type_year)$(
 
 * assign auxiliary variables DEMAND, PRICE_COMMODITY and PRICE_EMISSION for integration with MACRO and reporting
     DEMAND.l(node,commodity,level,year,time) = demand_fixed(node,commodity,level,year,time) ;
-    PRICE_COMMODITY.l(node,commodity,level,year,time) = ( COMMODITY_EQUIVALENCE.m(node,commodity,level,year,time) + 
-        COMMODITY_BALANCE_GT.m(node,commodity,level,year,time) - COMMODITY_BALANCE_LT.m(node,commodity,level,year,time) )
+    PRICE_COMMODITY.l(node,commodity,level,year,time) =
+        ( COMMODITY_BALANCE_GT.m(node,commodity,level,year,time) + COMMODITY_BALANCE_LT.m(node,commodity,level,year,time) )
             / discountfactor(year) ;
     PRICE_EMISSION.l(node,type_emission,type_tec,year)$( SUM(type_year$( cat_year(type_year,year) ), 1 ) ) =
             SMAX(type_year$( cat_year(type_year,year) ),

--- a/message_ix/model/MESSAGE_run.gms
+++ b/message_ix/model/MESSAGE_run.gms
@@ -81,9 +81,7 @@ import_cost(node2, commodity, year) =
 * import into node2 from other nodes
           input(node2,tec,vintage,year,mode,node,commodity,level,time2,time)
         * duration_time_rel(time,time2) * ACT.L(node2,tec,vintage,year,mode,time2)
-        * ( COMMODITY_EQUIVALENCE.m(node,commodity,level,year,time) + 
-          COMMODITY_BALANCE_GT.m(node,commodity,level,year,time) - COMMODITY_BALANCE_LT.m(node,commodity,level,year,time) )
-          / discountfactor(year) )
+        * PRICE_COMMODITY.l(node,commodity,level,year,time) )
 ;
 
 * calculation of commodity export costs by node, commodity and year
@@ -93,9 +91,7 @@ export_cost(node2, commodity, year) =
 * export from node2 to other market
           output(node2,tec,vintage,year,mode,node,commodity,level,time2,time)
         * duration_time_rel(time,time2) * ACT.L(node2,tec,vintage,year,mode,time2)
-        * ( COMMODITY_EQUIVALENCE.m(node,commodity,level,year,time) + 
-          COMMODITY_BALANCE_GT.m(node,commodity,level,year,time) - COMMODITY_BALANCE_LT.m(node,commodity,level,year,time) )
-          / discountfactor(year) )
+        * PRICE_COMMODITY.l(node,commodity,level,year,time) )
 ;
 
 * net commodity trade costs by node and year

--- a/tests/test_feature_price_commodity.py
+++ b/tests/test_feature_price_commodity.py
@@ -1,0 +1,48 @@
+import pytest
+from subprocess import CalledProcessError
+
+from message_ix import Scenario
+
+
+def model_setup(scen, var_cost=1):
+    scen.add_set('node', 'node')
+    scen.add_set('commodity', 'comm')
+    scen.add_set('level', 'level')
+    scen.add_set('year', 2020)
+
+    scen.add_par('demand', ['node', 'comm', 'level', 2020, 'year'],  1, 'GWa')
+
+    scen.add_set('technology', 'tec')
+    scen.add_set('mode', 'mode')
+    tec_specs = ['node', 'tec', 2020, 2020, 'mode']
+    output_specs = ['node', 'comm', 'level', 'year', 'year']
+    scen.add_par('output', tec_specs + output_specs, 1, 'GWa')
+    scen.add_par('var_cost', tec_specs + ['year'], var_cost, 'USD/GWa')
+
+
+def test_commodity_price(test_mp):
+    scen = Scenario(test_mp, 'test_commodity_price', 'standard', version='new')
+    model_setup(scen)
+    scen.commit('initialize test model')
+    scen.solve(case='price_commodity_standard')
+
+    assert scen.var('OBJ')['lvl'] == 1
+    assert scen.var('PRICE_COMMODITY')['lvl'][0] == 1
+
+
+def test_commodity_price_equality(test_mp):
+    scen = Scenario(test_mp, 'test_commodity_price', 'equality', version='new')
+    model_setup(scen, var_cost=-1)
+    scen.commit('initialize test model with negative variable costs')
+
+    # negative variable costs and supply >= demand causes an unbounded ray
+    pytest.raises(CalledProcessError, scen.solve)
+
+    # use the commodity-balance equality feature
+    scen.check_out()
+    scen.add_set('balance_equality', ['comm', 'level'])
+    scen.commit('set commodity-balance for `[comm, level]` as equality')
+    scen.solve(case='price_commodity_equality')
+
+    assert scen.var('OBJ')['lvl'] == -1
+    assert scen.var('PRICE_COMMODITY')['lvl'][0] == -1


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added

# Description

This PR refactors the GAMS code to correctly report commodity prices. It also adds two units tests to ensure that negative commodity prices in an equality-case are assigned correctly.